### PR TITLE
Refresh landing page styling and prompt groups

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,159 +1,324 @@
-<!DOCTYPE html><html lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>The Gospels AI — Ask a Question</title>
-  <meta name="description" content="Seek the wisdom of Jesus from the Gospel of Matthew using The Gospels AI." />
+  <meta name="description" content="Seek the wisdom of Jesus from all four Gospels using The Gospels AI." />
   <meta property="og:title" content="The Gospels AI — Ask a Question" />
-  <meta property="og:description" content="Seek the wisdom of Jesus from the Gospel of Matthew using The Gospels AI." />
+  <meta property="og:description" content="Seek the wisdom of Jesus from all four Gospels using The Gospels AI." />
   <meta property="og:type" content="website" />
   <style>
-    :root{
-      --bg:#0f172a;      /* slate-900 */
-      --panel:#111827;   /* gray-900 */
-      --muted:#94a3b8;   /* slate-400 */
-      --text:#e5e7eb;    /* gray-200 */
-      --accent:#fbbf24;  /* amber-400 */
-      --accent-2:#60a5fa;/* blue-400 */
-      --ring: rgba(251,191,36,.4);
+    :root {
+      --bg: #f6f7f9;
+      --panel: #ffffff;
+      --text: #1f2937;
+      --muted: #64748b;
+      --accent: #4f46e5;
+      --accent-soft: rgba(99, 102, 241, 0.1);
+      --ring: rgba(79, 70, 229, 0.2);
+      --shadow: 0 24px 60px rgba(15, 23, 42, 0.12);
     }
-    html,body{height:100%}
-    body{
-      margin:0; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica Neue, Arial, "Apple Color Emoji", "Segoe UI Emoji";
-      background: radial-gradient(1200px 600px at 20% 0%, rgba(96,165,250,.08), transparent),
-                  radial-gradient(900px 500px at 90% 10%, rgba(251,191,36,.08), transparent),
+
+    * {
+      box-sizing: border-box;
+    }
+
+    html,
+    body {
+      height: 100%;
+    }
+
+    body {
+      margin: 0;
+      font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Ubuntu, Cantarell,
+        "Noto Sans", Helvetica Neue, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+      background: radial-gradient(1000px 600px at 20% 10%, rgba(79, 70, 229, 0.08), transparent),
+                  radial-gradient(800px 500px at 80% 0%, rgba(14, 165, 233, 0.06), transparent),
                   var(--bg);
-      color:var(--text);
-      -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale;
+      color: var(--text);
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
     }
-    .wrapper{min-height:100%; display:grid; place-items:center; padding:24px}
-    .card{
-      width:min(960px, 100%);
-      background: linear-gradient(180deg, rgba(17,24,39,.9), rgba(17,24,39,.75));
-      border:1px solid rgba(148,163,184,.15);
-      border-radius:24px; padding:28px; box-shadow: 0 20px 60px rgba(0,0,0,.35);
-      backdrop-filter: blur(6px);
+
+    .wrapper {
+      min-height: 100%;
+      display: grid;
+      place-items: center;
+      padding: 32px 24px;
     }
-    .brand{display:flex; align-items:center; gap:14px; margin-bottom:14px}
-    .logo{width:40px; height:40px; border-radius:10px; background:
-      conic-gradient(from 210deg, var(--accent), var(--accent-2), var(--accent));
-      box-shadow: inset 0 0 0 2px rgba(255,255,255,.15), 0 6px 16px rgba(96,165,250,.2);
+
+    .card {
+      width: min(960px, 100%);
+      background: var(--panel);
+      border-radius: 28px;
+      border: 1px solid rgba(148, 163, 184, 0.18);
+      box-shadow: var(--shadow);
+      padding: 40px;
     }
-    h1{font-size:clamp(28px, 4vw, 44px); line-height:1.1; margin:0}
-    .subtitle{color:var(--muted); margin:12px 0 24px; font-size:clamp(14px, 2vw, 18px)}.form{display:flex; flex-direction:column; gap:12px}
-.inputWrap{display:flex; gap:10px; align-items:stretch; flex-wrap:wrap}
-.input{
-  flex:1 1 340px; min-height:54px; border-radius:16px; border:1px solid rgba(148,163,184,.35);
-  background:#0b1220; color:var(--text); padding:14px 16px; font-size:16px;
-  outline:none; transition: box-shadow .2s, border-color .2s;
-}
-.input:focus{ box-shadow:0 0 0 6px var(--ring); border-color:var(--accent); }
-.btn{
-  flex:0 0 auto; padding:14px 18px; border-radius:16px; border:1px solid rgba(251,191,36,.2);
-  background:linear-gradient(180deg, var(--accent), #f59e0b);
-  color:#1f2937; font-weight:700; letter-spacing:.2px; cursor:pointer; font-size:16px;
-  transition: transform .05s ease, box-shadow .2s ease;
-  box-shadow: 0 10px 24px rgba(251,191,36,.25);
-}
-.btn:active{ transform: translateY(1px) }
-.helper{color:var(--muted); font-size:13px; margin-top:4px}
 
-.chips{display:flex; flex-wrap:wrap; gap:8px; margin-top:18px}
-.chip{border:1px solid rgba(148,163,184,.25); color:#cbd5e1; padding:8px 12px; border-radius:999px; cursor:pointer; user-select:none;}
-.chip:hover{border-color:#94a3b8}
+    .brand {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      margin-bottom: 20px;
+    }
 
-.footer{margin-top:22px; display:flex; justify-content:space-between; gap:12px; flex-wrap:wrap; color:var(--muted); font-size:13px}
-.link{color:#c7d2fe; text-decoration:none}
-.link:hover{text-decoration:underline}
+    .logo {
+      width: 56px;
+      height: 56px;
+      border-radius: 16px;
+      object-fit: contain;
+      box-shadow: 0 14px 32px rgba(15, 23, 42, 0.16);
+    }
 
-.disclaimer{
-  margin-top:18px; font-size:12px; color:#9aa7bd; line-height:1.45;
-  background: rgba(2,6,23,.6); border:1px dashed rgba(148,163,184,.25);
-  padding:12px 14px; border-radius:12px;
-}
+    h1 {
+      font-size: clamp(32px, 4vw, 46px);
+      line-height: 1.1;
+      margin: 0;
+    }
 
+    .subtitle {
+      color: var(--muted);
+      margin: 14px 0 32px;
+      font-size: clamp(16px, 2vw, 19px);
+    }
+
+    .form {
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+    }
+
+    .inputWrap {
+      display: flex;
+      gap: 12px;
+      align-items: stretch;
+      flex-wrap: wrap;
+    }
+
+    .input {
+      flex: 1 1 340px;
+      min-height: 58px;
+      border-radius: 18px;
+      border: 1px solid rgba(148, 163, 184, 0.4);
+      background: #f8fafc;
+      color: var(--text);
+      padding: 16px 20px;
+      font-size: 16px;
+      outline: none;
+      transition: box-shadow 0.2s, border-color 0.2s;
+    }
+
+    .input:focus {
+      box-shadow: 0 0 0 6px var(--ring);
+      border-color: var(--accent);
+    }
+
+    .btn {
+      flex: 0 0 auto;
+      padding: 16px 26px;
+      border-radius: 18px;
+      border: 1px solid transparent;
+      background: linear-gradient(120deg, var(--accent), #6366f1);
+      color: #f8fafc;
+      font-weight: 700;
+      letter-spacing: 0.2px;
+      cursor: pointer;
+      font-size: 16px;
+      transition: transform 0.05s ease, box-shadow 0.2s ease;
+      box-shadow: 0 16px 32px rgba(79, 70, 229, 0.26);
+    }
+
+    .btn:active {
+      transform: translateY(1px);
+    }
+
+    .helper {
+      color: var(--muted);
+      font-size: 13px;
+      margin-top: 4px;
+    }
+
+    .prompt-groups {
+      display: grid;
+      gap: 20px;
+      margin-top: 32px;
+    }
+
+    .prompt-group {
+      background: linear-gradient(140deg, rgba(224, 231, 255, 0.65), rgba(240, 249, 255, 0.65));
+      padding: 22px 24px;
+      border-radius: 22px;
+      border: 1px solid rgba(148, 163, 184, 0.22);
+    }
+
+    .prompt-title {
+      margin: 0 0 14px;
+      font-size: 16px;
+      font-weight: 700;
+      color: var(--accent);
+      letter-spacing: 0.2px;
+    }
+
+    .chips {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+
+    .chip {
+      border: 1px solid rgba(99, 102, 241, 0.25);
+      color: #4338ca;
+      padding: 9px 14px;
+      border-radius: 999px;
+      cursor: pointer;
+      user-select: none;
+      background: var(--accent-soft);
+      transition: border-color 0.2s ease, transform 0.1s ease;
+    }
+
+    .chip:hover {
+      border-color: rgba(99, 102, 241, 0.55);
+      transform: translateY(-1px);
+    }
+
+    .footer {
+      margin-top: 36px;
+      display: flex;
+      justify-content: center;
+      gap: 12px;
+      flex-wrap: wrap;
+      color: var(--muted);
+      font-size: 13px;
+    }
+
+    @media (max-width: 640px) {
+      .card {
+        padding: 28px 22px;
+      }
+
+      .logo {
+        width: 48px;
+        height: 48px;
+      }
+    }
   </style>
 </head>
 <body>
   <main class="wrapper">
     <section class="card" aria-labelledby="title">
       <div class="brand">
-        <div class="logo" aria-hidden="true"></div>
+        <img class="logo" src="logo-gospelsai.png" alt="The Gospels AI logo" />
         <div>
-          <div style="font-weight:700; letter-spacing:.4px; color:#e2e8f0">The Gospels AI</div>
-          <div style="font-size:12px; color:#9ca3af">Grounded in the Gospel of Matthew</div>
+          <div style="font-weight:700; letter-spacing:.4px; color:#111827">The Gospels AI</div>
+          <div style="font-size:12px; color:#475569">Grounded in Matthew, Mark, Luke, and John</div>
         </div>
-      </div><h1 id="title">Seek the wisdom of Jesus</h1>
-  <p class="subtitle">Ask a real‑life question and jump straight into the custom GPT. Your question will auto‑fill so you can get an answer right away.</p>
+      </div>
 
-  <form id="ask-form" class="form" autocomplete="on">
-    <div class="inputWrap">
-      <input id="question" name="q" class="input" type="text" inputmode="text" minlength="3" maxlength="500" placeholder="e.g., How do I love my spouse well when I feel hurt?" aria-label="Your question" required />
-      <button class="btn" type="submit" aria-label="Ask Jesus via The Gospels AI">Ask</button>
-    </div>
-    <div id="helper" class="helper">Tip: Be specific. Your question is sent securely via the page URL to your custom GPT session.</div>
-  </form>
+      <h1 id="title">Seek the wisdom of Jesus</h1>
+      <p class="subtitle">Ask a real-life question and jump straight into the custom GPT. Your question will auto-fill so you can get an answer right away.</p>
 
-  <div class="chips" aria-label="Suggested prompts">
-    <span class="chip" data-prompt="How should I respond when someone mistreats me?">Respond to mistreatment</span>
-    <span class="chip" data-prompt="How can I forgive when it still hurts?">Forgiveness when it hurts</span>
-    <span class="chip" data-prompt="What does Jesus teach about anxiety and worry?">Anxiety & worry</span>
-    <span class="chip" data-prompt="How do I lead my family with love and truth?">Lead my family</span>
-  </div>
+      <form id="ask-form" class="form" autocomplete="on">
+        <div class="inputWrap">
+          <input id="question" name="q" class="input" type="text" inputmode="text" minlength="3" maxlength="500" placeholder="e.g., How do I love my spouse well when I feel hurt?" aria-label="Your question" required />
+          <button class="btn" type="submit" aria-label="Ask Jesus via The Gospels AI">Ask</button>
+        </div>
+        <div id="helper" class="helper">Tip: Be specific. Your question is sent securely via the page URL to your custom GPT session.</div>
+      </form>
 
-  <p class="disclaimer"><strong>Note:</strong> This launcher simply redirects you to your custom GPT at ChatGPT with your question attached as a <code>?q=</code> parameter. No questions are stored on this page.</p>
+      <div class="prompt-groups" aria-label="Suggested prompts">
+        <div class="prompt-group">
+          <h2 class="prompt-title">For Men</h2>
+          <div class="chips">
+            <span class="chip" data-prompt="How can I lead my household with humility like Jesus?">Lead with humility</span>
+            <span class="chip" data-prompt="What guidance do the Gospels give for balancing work and discipleship?">Work and discipleship</span>
+            <span class="chip" data-prompt="How should I handle conflict with other men in my church?">Conflict with brothers</span>
+            <span class="chip" data-prompt="How do I pursue purity in a culture that normalizes lust?">Pursuing purity</span>
+          </div>
+        </div>
+        <div class="prompt-group">
+          <h2 class="prompt-title">For Women</h2>
+          <div class="chips">
+            <span class="chip" data-prompt="How does Jesus honor the faith and leadership of women?">Faithful leadership</span>
+            <span class="chip" data-prompt="How can I support my friends through suffering the way Jesus did?">Supporting friends in suffering</span>
+            <span class="chip" data-prompt="What do the Gospels teach about finding my identity in Christ?">Identity in Christ</span>
+            <span class="chip" data-prompt="How do I love my family sacrificially without burning out?">Sacrificial love</span>
+          </div>
+        </div>
+        <div class="prompt-group">
+          <h2 class="prompt-title">For Families</h2>
+          <div class="chips">
+            <span class="chip" data-prompt="How can our family build rhythms of prayer like Jesus modeled?">Family prayer rhythms</span>
+            <span class="chip" data-prompt="What can we learn from Jesus about welcoming children?">Welcoming children</span>
+            <span class="chip" data-prompt="How do we handle disagreement at the dinner table with grace?">Grace at the table</span>
+            <span class="chip" data-prompt="How can we talk about forgiveness when trust is broken?">Family forgiveness</span>
+          </div>
+        </div>
+        <div class="prompt-group">
+          <h2 class="prompt-title">For Students &amp; Young Adults</h2>
+          <div class="chips">
+            <span class="chip" data-prompt="How do I stay faithful to Jesus when my classmates doubt Him?">Faith amid doubt</span>
+            <span class="chip" data-prompt="What does Jesus teach about choosing friends and influences?">Choosing friends</span>
+            <span class="chip" data-prompt="How should I respond when I feel anxious about the future?">Future anxiety</span>
+            <span class="chip" data-prompt="How can I serve my campus the way Jesus served others?">Serving my campus</span>
+          </div>
+        </div>
+      </div>
 
-  <div class="footer">
-    <span>© <span id="year"></span> The Gospels AI</span>
-    <span><a class="link" href="https://chatgpt.com/g/g-68d589f65adc8191bbe32c9b6dd7b6b3-the-gospels-ai" rel="noopener" target="_blank">Open the GPT directly</a></span>
-  </div>
-</section>
+      <div class="footer">
+        <span>© <span id="year"></span> The Gospels AI</span>
+      </div>
+    </section>
+  </main>
 
-  </main>  <script>
-    (function(){
+  <script>
+    (function () {
       const baseGPTUrl = "https://chatgpt.com/g/g-68d589f65adc8191bbe32c9b6dd7b6b3-the-gospels-ai";
-      const form = document.getElementById('ask-form');
-      const input = document.getElementById('question');
-      const helper = document.getElementById('helper');
-      const chips = document.querySelectorAll('.chip');
-      const yearEl = document.getElementById('year');
+      const form = document.getElementById("ask-form");
+      const input = document.getElementById("question");
+      const helper = document.getElementById("helper");
+      const chips = document.querySelectorAll(".chip");
+      const yearEl = document.getElementById("year");
       yearEl.textContent = new Date().getFullYear();
 
-      // Populate from existing ?q= if present (nice when returning back)
       const params = new URLSearchParams(window.location.search);
-      if(params.has('q')){
-        try { input.value = decodeURIComponent(params.get('q') || '').trim(); }
-        catch(e){ /* ignore */ }
+      if (params.has("q")) {
+        try {
+          input.value = decodeURIComponent(params.get("q") || "").trim();
+        } catch (e) {
+          /* ignore */
+        }
       }
 
-      chips.forEach(c => c.addEventListener('click', () => {
-        input.value = c.getAttribute('data-prompt');
-        input.focus();
-      }));
+      chips.forEach((chip) =>
+        chip.addEventListener("click", () => {
+          input.value = chip.getAttribute("data-prompt");
+          input.focus();
+        })
+      );
 
-      form.addEventListener('submit', (e) => {
-        e.preventDefault();
+      form.addEventListener("submit", (event) => {
+        event.preventDefault();
         const q = input.value.trim();
-        if(q.length < 3){
-          helper.textContent = 'Please enter a bit more detail (min 3 characters).';
+        if (q.length < 3) {
+          helper.textContent = "Please enter a bit more detail (min 3 characters).";
           input.focus();
           return;
         }
         const encoded = encodeURIComponent(q);
-        // If the base URL already contains a query string, append with &; otherwise, start with ?
-        const joiner = baseGPTUrl.includes('?') ? '&' : '?';
+        const joiner = baseGPTUrl.includes("?") ? "&" : "?";
         const targetUrl = `${baseGPTUrl}${joiner}q=${encoded}`;
-        // Navigate to the custom GPT with the q parameter attached
         window.location.href = targetUrl;
       });
 
-      // Allow Cmd/Ctrl+Enter to submit
-      input.addEventListener('keydown', (e) => {
-        if((e.key === 'Enter' && (e.metaKey || e.ctrlKey))){
-          e.preventDefault();
+      input.addEventListener("keydown", (event) => {
+        if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+          event.preventDefault();
           form.requestSubmit();
         }
       });
     })();
-  </script></body>
+  </script>
+</body>
 </html>


### PR DESCRIPTION
## Summary
- restyle the landing page with a bright white palette, softer gradients, and refreshed input/button treatments
- place the provided logo next to the title and update copy to reference all four Gospels
- expand suggested prompts into multiple audience-specific groups while simplifying the footer content

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d722b4d4248331b83591aa7206d2ba