### PR TITLE
Add PWA support with manifest and service worker

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,10 @@
   <meta property="og:title" content="The Gospel AI — Ask a Question" />
   <meta property="og:description" content="Seek the wisdom of Jesus using The Gospel AI." />
   <meta property="og:type" content="website" />
+  <meta name="theme-color" content="#4f46e5" />
+  <link rel="icon" type="image/png" href="logo-gospelai.png" />
+  <link rel="apple-touch-icon" href="logo-gospelai.png" />
+  <link rel="manifest" href="manifest.webmanifest" />
   <style>
     :root {
       --bg: #f6f7f9;
@@ -351,6 +355,14 @@
           form.requestSubmit();
         }
       });
+
+      if ("serviceWorker" in navigator) {
+        window.addEventListener("load", () => {
+          navigator.serviceWorker.register("service-worker.js").catch(() => {
+            /* noop */
+          });
+        });
+      }
     })();
   </script>
 </body>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,17 @@
+{
+  "name": "The Gospel AI",
+  "short_name": "Gospel AI",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#f6f7f9",
+  "theme_color": "#4f46e5",
+  "description": "Seek the wisdom of Jesus from the Gospels with Gospel AI.",
+  "icons": [
+    {
+      "src": "logo-gospelai.png",
+      "sizes": "1024x1024",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,58 @@
+const CACHE_NAME = "gospel-ai-cache-v1";
+const OFFLINE_ASSETS = [
+  "./",
+  "index.html",
+  "logo-gospelai.png",
+  "manifest.webmanifest"
+];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches
+      .open(CACHE_NAME)
+      .then((cache) => cache.addAll(OFFLINE_ASSETS))
+      .then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((cacheNames) =>
+        Promise.all(
+          cacheNames.map((name) => {
+            if (name !== CACHE_NAME) {
+              return caches.delete(name);
+            }
+            return undefined;
+          })
+        )
+      )
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  if (event.request.method !== "GET") {
+    return;
+  }
+
+  event.respondWith(
+    caches.match(event.request).then((cachedResponse) => {
+      if (cachedResponse) {
+        return cachedResponse;
+      }
+
+      return fetch(event.request)
+        .then((response) => {
+          const clonedResponse = response.clone();
+          caches.open(CACHE_NAME).then((cache) => {
+            cache.put(event.request, clonedResponse);
+          });
+          return response;
+        })
+        .catch(() => caches.match("index.html"));
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- add web app manifest referencing the Gospel AI branding and launch settings
- register a service worker in the main page to enable offline caching
- implement a cache-first service worker for core assets and offline fallback

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d72d4cd0148331b093b18eb71cba0e