### PR TITLE
Improve PWA install modal fallback handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -271,6 +271,35 @@
       color: var(--accent);
     }
 
+    .install-instructions {
+      width: 100%;
+      text-align: left;
+      background: #f8fafc;
+      border-radius: 18px;
+      border: 1px solid rgba(148, 163, 184, 0.32);
+      padding: 18px 20px;
+    }
+
+    .install-instructions p {
+      margin-top: 0;
+      margin-bottom: 12px;
+      color: var(--muted);
+      font-size: 14px;
+    }
+
+    .install-instructions ol {
+      margin: 0 0 12px 18px;
+      padding: 0;
+    }
+
+    .install-instructions li {
+      margin-bottom: 8px;
+    }
+
+    .install-instructions[hidden] {
+      display: none;
+    }
+
     .share-qr {
       width: 220px;
       height: 220px;
@@ -453,6 +482,20 @@
       <p>Install the Gospel AI app to keep Scripture-guided wisdom just a tap away.</p>
       <button id="install-action" class="btn" type="button" disabled>Install Gospel AI</button>
       <div id="install-status" class="install-status" role="status" aria-live="polite"></div>
+      <div id="install-instructions" class="install-instructions" hidden>
+        <p>
+          Safari on iPhone or iPad doesn’t show an automatic install prompt. Follow these steps to
+          add Gospel AI to your Home Screen:
+        </p>
+        <ol>
+          <li>Tap the <strong>Share</strong> button in Safari’s toolbar (the square with an arrow).</li>
+          <li>Scroll down and choose <strong>Add to Home Screen</strong>.</li>
+          <li>Confirm by tapping <strong>Add</strong>. Gospel AI will open like a native app.</li>
+        </ol>
+        <p style="margin-bottom:0; font-size:13px; color:var(--muted)">
+          When you’re done, tap “I’ve added Gospel AI” so we can close this dialog.
+        </p>
+      </div>
     </div>
   </div>
 
@@ -496,10 +539,16 @@
       const installModalBackdrop = document.getElementById("install-modal");
       const installActionButton = document.getElementById("install-action");
       const installStatus = document.getElementById("install-status");
+      const installInstructions = document.getElementById("install-instructions");
       const shareUrl = "https://drs-az.github.io/GospelAI";
       const shareText = "Check out Gospel AI to seek the wisdom of Jesus through Scripture.";
       const installStorageKey = "gospelaiPwaInstalled";
       let deferredInstallPrompt = null;
+      let manualInstallMode = false;
+      let installPromptTimeoutId = null;
+      const manualInstallStatusText =
+        'Follow the steps below to add Gospel AI to your Home Screen, then tap "I\'ve added Gospel AI."';
+      const installPromptSupported = "BeforeInstallPromptEvent" in window;
 
       yearEl.textContent = new Date().getFullYear();
 
@@ -543,6 +592,46 @@
       const isInstallModalActive = () =>
         installModalBackdrop && installModalBackdrop.classList.contains("active");
 
+      const exitManualInstallMode = () => {
+        if (!manualInstallMode) {
+          return;
+        }
+        manualInstallMode = false;
+        if (installInstructions) {
+          installInstructions.hidden = true;
+        }
+        if (installActionButton) {
+          delete installActionButton.dataset.mode;
+          if (installActionButton.textContent !== "Installing…") {
+            installActionButton.textContent = "Install Gospel AI";
+          }
+        }
+      };
+
+      const enterManualInstallMode = (statusMessage) => {
+        if (manualInstallMode) {
+          if (installStatus && statusMessage) {
+            installStatus.textContent = statusMessage;
+          }
+          return;
+        }
+        manualInstallMode = true;
+        if (installInstructions) {
+          installInstructions.hidden = false;
+        }
+        if (installActionButton) {
+          installActionButton.disabled = false;
+          installActionButton.dataset.mode = "manual";
+          installActionButton.textContent = "I've added Gospel AI";
+          if (isInstallModalActive()) {
+            installActionButton.focus();
+          }
+        }
+        if (installStatus) {
+          installStatus.textContent = statusMessage || manualInstallStatusText;
+        }
+      };
+
       const hideInstallModal = () => {
         if (!installModalBackdrop) {
           return;
@@ -575,6 +664,11 @@
       };
 
       const markPwaInstalled = () => {
+        exitManualInstallMode();
+        if (installPromptTimeoutId) {
+          window.clearTimeout(installPromptTimeoutId);
+          installPromptTimeoutId = null;
+        }
         localStorage.setItem(installStorageKey, "true");
         if (installActionButton) {
           installActionButton.disabled = true;
@@ -598,9 +692,18 @@
       } else {
         if (installStatus) {
           installStatus.textContent =
-            "Install the Gospel AI PWA to continue. The install button will activate shortly if supported.";
+            "Install the Gospel AI PWA to continue. We'll enable the install option as soon as it's available.";
         }
         showInstallModal();
+        if (!installPromptSupported) {
+          enterManualInstallMode(manualInstallStatusText);
+        } else {
+          installPromptTimeoutId = window.setTimeout(() => {
+            if (!deferredInstallPrompt) {
+              enterManualInstallMode(manualInstallStatusText);
+            }
+          }, 6000);
+        }
       }
 
       const handleStandaloneChange = (event) => {
@@ -620,6 +723,11 @@
       window.addEventListener("beforeinstallprompt", (event) => {
         event.preventDefault();
         deferredInstallPrompt = event;
+        if (installPromptTimeoutId) {
+          window.clearTimeout(installPromptTimeoutId);
+          installPromptTimeoutId = null;
+        }
+        exitManualInstallMode();
         if (installActionButton) {
           installActionButton.disabled = false;
           installActionButton.textContent = "Install Gospel AI";
@@ -634,6 +742,10 @@
 
       if (installActionButton) {
         installActionButton.addEventListener("click", async () => {
+          if (installActionButton.dataset.mode === "manual") {
+            markPwaInstalled();
+            return;
+          }
           if (!deferredInstallPrompt) {
             if (installStatus) {
               installStatus.textContent =


### PR DESCRIPTION
## Summary
- add manual install instructions and fallback messaging when the browser does not surface a beforeinstallprompt event
- repurpose the install action button so users can confirm manual installation and close the modal once complete
- style the install modal with inline guidance for Safari/iOS users while keeping supported browsers on the standard flow

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d81a17c20883318a47bf8b690cd824